### PR TITLE
Tmux bin

### DIFF
--- a/items/advanced.sh
+++ b/items/advanced.sh
@@ -34,14 +34,14 @@ open_menu="run-shell '$CURRENT_DIR"
 #
 #  Gather some info in order to be able to show states
 #
-current_mouse_status="$(tmux show-option -g mouse | cut -d' ' -f2)"
+current_mouse_status="$($TMUX_BIN show-option -g mouse | cut -d' ' -f2)"
 if [ "$current_mouse_status" = "on" ]; then
     new_mouse_status="off"
 else
 
     new_mouse_status="on"
 fi
-current_prefix="$(tmux show-option -g prefix | cut -d' ' -f2 | cut -d'-' -f2)"
+current_prefix="$($TMUX_BIN show-option -g prefix | cut -d' ' -f2 | cut -d'-' -f2)"
 
 
 describe_prefix="command-prompt -k -p key 'list-keys -1N \"%%%\"'"
@@ -60,7 +60,7 @@ plugin_conf_prompt="$*"
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154,SC2140
-tmux display-menu                                                           \
+$TMUX_BIN display-menu                                                           \
     -T "#[align=centre] $menu_name "                                        \
     -x "$menu_location_x" -y "$menu_location_y"                             \
                                                                             \

--- a/items/advanced_manage_clients.sh
+++ b/items/advanced_manage_clients.sh
@@ -33,7 +33,7 @@ open_menu="run-shell '$CURRENT_DIR"
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                                           \
+$TMUX_BIN display-menu                                                           \
     -T "#[align=centre] $menu_name "                                        \
     -x "$menu_location_x" -y "$menu_location_y"                             \
                                                                             \

--- a/items/config.sh
+++ b/items/config.sh
@@ -47,7 +47,7 @@ set_coordinates="$*"
 t_start="$(date +'%s')"  #  if the menu closed in < 1s assume it didnt fit
 
 # shellcheck disable=SC2154
-tmux display-menu                                                   \
+$TMUX_BIN display-menu                                                   \
     -T "#[align=centre] $menu_name "                                \
     -x "$menu_location_x" -y "$menu_location_y"                     \
                                                                     \

--- a/items/extras.sh
+++ b/items/extras.sh
@@ -5,7 +5,7 @@
 #
 #   Part of https://github.com/jaclu/tmux-menus
 #
-#   Version: 1.0.1 2022-07-28
+#   Version: 1.0.2 2022-09-14
 #
 #   Handling pane
 #
@@ -55,11 +55,11 @@ $TMUX_BIN display-menu                                                       \
     "Back to Main menu"  Left  "$open_menu/main.sh'"                    \
     ""                                                                  \
     "$(is_avalable dropbox Dropbox)  -->"        D                      \
-            "$open_extra/dropbox.sh"                                    \
+            "$open_extra/dropbox.sh'"                                    \
     "$(is_avalable spotify Spotify)  -->"        S                      \
-            "$open_extra/spotify.sh"                                    \
+            "$open_extra/spotify.sh'"                                    \
     "$(is_avalable mullvad "Mullvad VPN")  -->"  M                      \
-            "$open_extra/mullvad.sh"                                    \
+            "$open_extra/mullvad.sh'"                                    \
     ""                                                                  \
     "Help  -->"  H  "$open_menu/help_extras.sh $this_menu'"
 

--- a/items/extras.sh
+++ b/items/extras.sh
@@ -49,7 +49,7 @@ is_avalable() {
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                                       \
+$TMUX_BIN display-menu                                                       \
     -T "#[align=centre] Extras "                                        \
     -x "$menu_location_x" -y "$menu_location_y"                         \
     "Back to Main menu"  Left  "$open_menu/main.sh'"                    \

--- a/items/extras/_dropbox_toggle.sh
+++ b/items/extras/_dropbox_toggle.sh
@@ -41,10 +41,10 @@ fi
 #  Temp set a very high disp time, org value
 #  will be restored when script is done
 #
-org_disp_time="$(tmux show -g display-time | cut -d' ' -f 2)"
-tmux set-option -g display-time 30000
+org_disp_time="$($TMUX_BIN show -g display-time | cut -d' ' -f 2)"
+$TMUX_BIN set-option -g display-time 30000
 
-tmux display "Doing dropbox $action ..."
+$TMUX_BIN display "Doing dropbox $action ..."
 
 
 if [ "$action" = "start" ]; then
@@ -76,11 +76,11 @@ log_it "status change completed"
 #
 # Hack to clear msg
 #
-tmux set-option -g display-time 1
-tmux display ""
+$TMUX_BIN set-option -g display-time 1
+$TMUX_BIN display ""
 
 
 # Restore org value
-tmux set-option -g display-time "$org_disp_time"
+$TMUX_BIN set-option -g display-time "$org_disp_time"
 
 exit 0

--- a/items/extras/_mullvad_country.sh
+++ b/items/extras/_mullvad_country.sh
@@ -37,7 +37,7 @@ open_menu="run-shell '$ITEMS_DIR"
 
 offset="${1:-0}"  #  optional param indicating first item to display
 
-lines="$(tmux display -p '#{window_height}')"
+lines="$($TMUX_BIN display -p '#{window_height}')"
 display_items=$(( lines - 7 ))
 max_item=$(( offset + display_items ))
 
@@ -131,7 +131,7 @@ menu_items="$menu_items $nav"
 t_start="$(date +'%s')"
 
 #  shellcheck disable=SC2086,SC2090,SC2154
-echo $menu_items | xargs tmux display-menu -T "#[align=centre] $menu_name "  \
+echo $menu_items | xargs $TMUX_BIN display-menu -T "#[align=centre] $menu_name "  \
     -x $menu_location_x -y $menu_location_y
 
 ensure_menu_fits_on_screen

--- a/items/extras/dropbox.sh
+++ b/items/extras/dropbox.sh
@@ -32,7 +32,7 @@ open_menu="run-shell '$ITEMS_DIR"
 
 
 if [ -z "$(command -v dropbox)" ]; then
-    tmux display "dropbox bin not found!"
+    $TMUX_BIN display "dropbox bin not found!"
     exit 1
 fi
 
@@ -47,7 +47,7 @@ fi
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                                   \
+$TMUX_BIN display-menu                                                   \
     -T "#[align=centre] $menu_name "                                \
     -x "$menu_location_x" -y "$menu_location_y"                     \
                                                                     \

--- a/items/extras/mullvad.sh
+++ b/items/extras/mullvad.sh
@@ -34,7 +34,7 @@ suffix=" > /dev/null' ; run-shell '$this_menu'"
 
 
 if [ -z "$(command -v mullvad)" ]; then
-    tmux display "mullvad bin not found!"
+    $TMUX_BIN display "mullvad bin not found!"
     exit 1
 fi
 
@@ -71,7 +71,7 @@ fi
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                                           \
+$TMUX_BIN display-menu                                                           \
     -T "#[align=centre] $menu_name "                                        \
     -x "$menu_location_x" -y "$menu_location_y"                             \
                                                                             \

--- a/items/extras/spotify.sh
+++ b/items/extras/spotify.sh
@@ -34,7 +34,7 @@ suffix=" > /dev/null' ; run-shell '$this_menu'"
 
 
 if [ -z "$(command -v spotify)" ]; then
-    tmux display "spotify bin not found!"
+    $TMUX_BIN display "spotify bin not found!"
     exit 1
 fi
 
@@ -42,7 +42,7 @@ fi
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                                   \
+$TMUX_BIN display-menu                                                   \
     -T "#[align=centre] $menu_name "                                \
     -x "$menu_location_x" -y "$menu_location_y"                     \
                                                                     \

--- a/items/help.sh
+++ b/items/help.sh
@@ -36,7 +36,7 @@ fi
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                               \
+$TMUX_BIN display-menu                                               \
     -T "#[align=centre] $menu_name "                            \
     -x "$menu_location_x" -y "$menu_location_y"                 \
                                                                 \

--- a/items/help_extras.sh
+++ b/items/help_extras.sh
@@ -36,7 +36,7 @@ fi
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                               \
+$TMUX_BIN display-menu                                               \
     -T "#[align=centre] $menu_name "                            \
     -x "$menu_location_x" -y "$menu_location_y"                 \
                                                                 \

--- a/items/help_panes.sh
+++ b/items/help_panes.sh
@@ -36,7 +36,7 @@ fi
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                               \
+$TMUX_BIN display-menu                                               \
     -T "#[align=centre] $menu_name "                            \
     -x "$menu_location_x" -y "$menu_location_y"                 \
                                                                 \

--- a/items/help_split.sh
+++ b/items/help_split.sh
@@ -39,7 +39,7 @@ t_start="$(date +'%s')"
 #        in order to actually print one, figure out what's going on
 #
 # shellcheck disable=SC2154
-tmux display-menu                                               \
+$TMUX_BIN display-menu                                               \
     -T "#[align=centre] $menu_name   "                          \
     -x "$menu_location_x" -y "$menu_location_y"                 \
                                                                 \

--- a/items/help_window_move.sh
+++ b/items/help_window_move.sh
@@ -35,7 +35,7 @@ fi
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                               \
+$TMUX_BIN display-menu                                               \
     -T "#[align=centre] $menu_name "                            \
     -x "$menu_location_x" -y "$menu_location_y"                 \
                                                                 \

--- a/items/layouts.sh
+++ b/items/layouts.sh
@@ -33,7 +33,7 @@ open_menu="run-shell '$CURRENT_DIR"
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                       \
+$TMUX_BIN display-menu                                       \
     -T "#[align=centre] $menu_name "                    \
     -x "$menu_location_x" -y "$menu_location_y"         \
                                                         \

--- a/items/main.sh
+++ b/items/main.sh
@@ -34,14 +34,14 @@ open_menu="run-shell '$CURRENT_DIR"
 #  Thus I can't use spaces in the below display statements
 #
 set --  "command-prompt -I '~/.tmux.conf' -p 'Source file:'"            \
-        "'run-shell \"tmux source-file %% && tmux display Sourced_it!"  \
-        "|| tmux display File_could_not_be_sourced-not_found?  \"'"
+        "'run-shell \"$TMUX_BIN source-file %% && $TMUX_BIN display Sourced_it!"  \
+        "|| $TMUX_BIN display File_could_not_be_sourced-not_found?  \"'"
 source_it="$*"
 
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                                       \
+$TMUX_BIN display-menu                                                       \
     -T "#[align=centre] $menu_name "                                    \
     -x "$menu_location_x" -y "$menu_location_y"                         \
                                                                         \

--- a/items/pane_buffers.sh
+++ b/items/pane_buffers.sh
@@ -32,7 +32,7 @@ open_menu="run-shell '$CURRENT_DIR"
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                                       \
+$TMUX_BIN display-menu                                                       \
     -T "#[align=centre] $menu_name "                                    \
     -x "$menu_location_x" -y "$menu_location_y"                         \
                                                                         \

--- a/items/pane_move.sh
+++ b/items/pane_move.sh
@@ -43,7 +43,7 @@ t_start="$(date +'%s')"
 #  not to expand into the shortcuts if no pane is marked
 #
 # shellcheck disable=SC2154
-tmux display-menu                                                       \
+$TMUX_BIN display-menu                                                       \
     -T "#[align=centre] $menu_name "                                    \
     -x "$menu_location_x" -y "$menu_location_y"                         \
                                                                         \

--- a/items/pane_resize.sh
+++ b/items/pane_resize.sh
@@ -35,7 +35,7 @@ open_menu="run-shell '$CURRENT_DIR"
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                                   \
+$TMUX_BIN display-menu                                                   \
     -T "#[align=centre] $menu_name "                                \
     -x "$menu_location_x" -y "$menu_location_y"                     \
                                                                     \

--- a/items/panes.sh
+++ b/items/panes.sh
@@ -57,7 +57,7 @@ kill_others="$kill_others all other panes? (y/n)' 'kill-pane -a'"
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                                           \
+$TMUX_BIN display-menu                                                           \
     -T "#[align=centre] Handling Pane "                                     \
     -x "$menu_location_x" -y "$menu_location_y"                             \
                                                                             \

--- a/items/sessions.sh
+++ b/items/sessions.sh
@@ -46,7 +46,7 @@ kill_other="$*"
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                                       \
+$TMUX_BIN display-menu                                                       \
     -T "#[align=centre] $menu_name "                                    \
     -x "$menu_location_x" -y "$menu_location_y"                         \
                                                                         \

--- a/items/split_view.sh
+++ b/items/split_view.sh
@@ -33,7 +33,7 @@ open_menu="run-shell '$CURRENT_DIR"
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                                           \
+$TMUX_BIN display-menu                                                           \
     -T "#[align=centre] $menu_name "                                        \
     -x "$menu_location_x" -y "$menu_location_y"                             \
                                                                             \

--- a/items/window_move.sh
+++ b/items/window_move.sh
@@ -41,7 +41,7 @@ open_menu="run-shell '$CURRENT_DIR"
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                                           \
+$TMUX_BIN display-menu                                                           \
     -T "#[align=centre] $menu_name "                                        \
     -x "$menu_location_x" -y "$menu_location_y"                             \
                                                                             \

--- a/items/windows.sh
+++ b/items/windows.sh
@@ -48,7 +48,7 @@ kill_other="$*"
 t_start="$(date +'%s')"
 
 # shellcheck disable=SC2154
-tmux display-menu                                                       \
+$TMUX_BIN display-menu                                                       \
     -T "#[align=centre] $menu_name   "                                  \
     -x "$menu_location_x" -y "$menu_location_y"                         \
                                                                         \

--- a/menus.tmux
+++ b/menus.tmux
@@ -72,4 +72,4 @@ else
 fi
 
 #  shellcheck disable=SC2086,SC2090
-tmux bind $params "$trigger_key" run-shell "$MENUS_DIR/main.sh"
+$TMUX_BIN bind $params "$trigger_key" run-shell "$MENUS_DIR/main.sh"

--- a/scripts/break_pane.sh
+++ b/scripts/break_pane.sh
@@ -10,8 +10,8 @@
 #   Breaks pane to new window as long as there was more than one pane in current
 #
 
-if [ "$(tmux list-panes | wc -l)" -lt 2 ]; then
-    tmux display-message "Only one pane!"
+if [ "$($TMUX_BIN list-panes | wc -l)" -lt 2 ]; then
+    $TMUX_BIN display-message "Only one pane!"
 else
-    tmux command-prompt -I "#W"  -p "New window name: " "break-pane -n '%%'"
+    $TMUX_BIN command-prompt -I "#W"  -p "New window name: " "break-pane -n '%%'"
 fi

--- a/scripts/change_prefix.sh
+++ b/scripts/change_prefix.sh
@@ -25,6 +25,6 @@ fi
 
 prefix="C-${prefix_char}"
 
-tmux set-option -g prefix "$prefix"
+$TMUX_BIN set-option -g prefix "$prefix"
 
-tmux display-message "Be aware <prefix> is now: $prefix"
+$TMUX_BIN display-message "Be aware <prefix> is now: $prefix"

--- a/scripts/kill_current_session.sh
+++ b/scripts/kill_current_session.sh
@@ -24,9 +24,9 @@ CURRENT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
 force_directive="force"
 
-ses_count="$(tmux list-sessions | wc -l)"
+ses_count="$($TMUX_BIN list-sessions | wc -l)"
 
-ses_to_go="$(tmux display-message -p '#{session_id}')"
+ses_to_go="$($TMUX_BIN display-message -p '#{session_id}')"
 
 
 if [ -z "$ses_to_go" ]; then
@@ -50,7 +50,7 @@ fi
 #  Switch to next session, in order not to get disconnected when active session
 #  is terminated.
 #
-tmux switch-client -n &
+$TMUX_BIN switch-client -n &
 
 
 if [ "$ses_count" -gt 1 ]; then
@@ -66,4 +66,4 @@ if [ "$ses_count" -gt 1 ]; then
 fi
 
 
-tmux kill-session -t "$ses_to_go"
+$TMUX_BIN kill-session -t "$ses_to_go"

--- a/scripts/kill_other_windows.sh
+++ b/scripts/kill_other_windows.sh
@@ -10,11 +10,11 @@
 #   Kill all other windows
 #
 
-window_list="$(IFS=" " tmux list-windows -F '#{window_id}')"
-current_window="$(tmux display-message -p '#{window_id}')"
+window_list="$(IFS=" " $TMUX_BIN list-windows -F '#{window_id}')"
+current_window="$($TMUX_BIN display-message -p '#{window_id}')"
 
 for w in $window_list; do
     if [ "$w" != "$current_window" ]; then
-        tmux kill-window -t "$w"
+        $TMUX_BIN kill-window -t "$w"
     fi
 done

--- a/scripts/kill_session_confirm.sh
+++ b/scripts/kill_session_confirm.sh
@@ -20,5 +20,5 @@ set --  "Only one session, you will be disconnected if you continue."  \
         "Proceed? (y/n)"
 prompt="$*"
 
-tmux confirm-before -p "$prompt" \
+$TMUX_BIN confirm-before -p "$prompt" \
     "run \"$CURRENT_DIR/kill_current_session.sh force\""

--- a/scripts/relocate_pane.sh
+++ b/scripts/relocate_pane.sh
@@ -24,12 +24,12 @@ CURRENT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 param_check "$@"
 
 
-tmux move-pane -t "${dest_ses}:${dest_win_idx}.${dest_pane_idx}"
+$TMUX_BIN move-pane -t "${dest_ses}:${dest_win_idx}.${dest_pane_idx}"
 
 if [ "$cur_ses" != "$dest_ses" ]; then
     #
     #  When Window / Pane is moved to another session, focus does not
     #  auto-switch, so this manually sets focus.
     #
-    tmux switch-client -t "$dest_ses"  # switch focus to new location
+    $TMUX_BIN switch-client -t "$dest_ses"  # switch focus to new location
 fi

--- a/scripts/relocate_param_check.sh
+++ b/scripts/relocate_param_check.sh
@@ -65,7 +65,7 @@ param_check() {
     fi
 
 
-    cur_ses="$(tmux display-message -p '#S')"
+    cur_ses="$($TMUX_BIN display-message -p '#S')"
     dest="${raw_dest#*=}"  # skipping initial =
     dest_ses="${dest%%:*}" # up to first colon excluding it
 

--- a/scripts/relocate_window.sh
+++ b/scripts/relocate_window.sh
@@ -42,30 +42,30 @@ if [ "$cur_ses" = "$dest_ses" ]; then
     #
     #  Move within the current session
     #
-    tmux move-window -b -t ":${dest_win_idx}"
+    $TMUX_BIN move-window -b -t ":${dest_win_idx}"
 else
     #
     #  tmux move only works in same session, so we use link & unlink for
     #  moving to another session
     #
-    tmux link-window -b -t "$dest_ses:$dest_win_idx" # Create a link to this at destination
+    $TMUX_BIN link-window -b -t "$dest_ses:$dest_win_idx" # Create a link to this at destination
     if [ "$action" != "L" ]; then
         #
         # Unlink window at current location, ie get rid of original instance
         # And re-indix previous session
         #
-        tmux unlink-window
+        $TMUX_BIN unlink-window
     fi
     #
     #  When Window / Pane is moved to another session, focus does not
     #  auto-switch, so this manually sets focus.
     #
-    tmux switch-client -t "$dest_ses"  # switch focus to new location
+    $TMUX_BIN switch-client -t "$dest_ses"  # switch focus to new location
 fi
 
 if [ -z "$dest_win_idx" ]; then
     #
     # No dest windows idx given, assume it should go last
     #
-    tmux move-window -t 999
+    $TMUX_BIN move-window -t 999
 fi

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -36,13 +36,13 @@ config_file="/tmp/tmux-menus.conf"
 
 #
 #  I use an env var TMUX_BIN to point at the current tmux, defined in my
-#  tmux.conf, in order to pick the right version, when using ASDF,
-#  and testing various versions for backwards compatibility.
-#   If not found, it is set to whatever is in path, so should have no negative
+#  tmux.conf, in order to pick the version matching the server running.
+#  This is needed when checking backwards compatability with various versions.
+#  If not found, it is set to whatever is in path, so should have no negative
 #  impact. In all calls to tmux I use $TMUX_BIN instead in the rest of this
 #  plugin.
 #
-[ -z "$TMUX_BIN" ] && TMUX_BIN="$(command -v tmux)"
+[ -z "$TMUX_BIN" ] && TMUX_BIN="tmux"
 
 
 #

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -34,6 +34,16 @@ plugin_name="tmux-menus"
 #
 config_file="/tmp/tmux-menus.conf"
 
+#
+#  I use an env var TMUX_BIN to point at the current tmux, defined in my
+#  tmux.conf, in order to pick the right version, when using ASDF,
+#  and testing various versions for backwards compatibility.
+#   If not found, it is set to whatever is in path, so should have no negative
+#  impact. In all calls to tmux I use $TMUX_BIN instead in the rest of this
+#  plugin.
+#
+[ -z "$TMUX_BIN" ] && TMUX_BIN="$(command -v tmux)"
+
 
 #
 #  If $log_file is empty or undefined, no logging will occur.
@@ -57,9 +67,9 @@ error_msg() {
     log_it "$em_msg"
     em_msg="$plugin_name $em_msg"
     em_msg_len="$(printf "%s" "$em_msg" | wc -m)"
-    em_screen_width="$(tmux display -p "#{window_width}")"
+    em_screen_width="$($TMUX_BIN display -p "#{window_width}")"
     if [ "$em_msg_len" -le "$em_screen_width" ]; then
-        tmux display-message "$em_msg"
+        $TMUX_BIN display-message "$em_msg"
     else
         #
         #  Screen is to narrow to use display message
@@ -108,7 +118,7 @@ bool_param() {
 get_tmux_option() {
     gtm_option=$1
     gtm_default=$2
-    gtm_value=$(tmux show-option -gqv "$gtm_option")
+    gtm_value=$($TMUX_BIN show-option -gqv "$gtm_option")
     if [ -z "$gtm_value" ]; then
         echo "$gtm_default"
     else
@@ -130,7 +140,7 @@ get_tmux_option() {
 #  set, and that this sequence is done in the menu code:
 #
 #    t_start="$(date +'%s')"
-#    tmux display-menu ...
+#    $TMUX_BIN display-menu ...
 #    ensure_menu_fits_on_screen
 #
 #  Not perfect, but it kind of works. If you hit escape and instantly close
@@ -159,9 +169,9 @@ ensure_menu_fits_on_screen() {
            "w:$req_win_width h:$req_win_height"
     log_it "$*"
 
-    cur_width="$(tmux display -p "#{window_width}")"
+    cur_width="$($TMUX_BIN display -p "#{window_width}")"
     log_it "Current width: $cur_width"
-    cur_height="$(tmux display -p "#{window_height}")"
+    cur_height="$($TMUX_BIN display -p "#{window_height}")"
     log_it "Current height: $cur_height"
 
     if    [ "$cur_width" -lt "$req_win_width" ] || \


### PR DESCRIPTION
In order to be able to test various versions of tmux for compatibility with plugins, I used ASDF.
This has the drawback of using ~/.asdf/shims/tmux thus not allowing the path to tmux itself to identify what tmux to run, so I have set up my tmux.conf to identify the actual tmux in that case. When using ASDF the actual path to tmux (example: ~/.asdf/installs/tmux/2.8/bin/tmux) is identified and stored in the env variable TMUX_BIN

Using $TMUX_BIN whenever the plugin needs to access tmux from the shell, ensures that the plugin uses the tmux associated with the running session. This makes my testing much more convenient since I don't have to kill my main tmux each time I want to test a specific version, I just run a separate tmux under the version being tested.
This should not have any impact if TMUX_BIN is not used, since then it defaults to just being 'tmux'