### PR TITLE
Fix macos bash compatibility

### DIFF
--- a/scripts/plugins.sh
+++ b/scripts/plugins.sh
@@ -39,7 +39,7 @@ d_tpm="$plugins_dir"/tpm
 #
 #  List of plugins defined in config file
 #
-if [[ -d /proc/ish ]]; then
+if [[ ! $(command -v mapfile) ]] || [[ -d /proc/ish ]]; then
     # iSH has very limited /dev impl, doesnt support mapfile
     #  shellcheck disable=SC2207
     defined_plugins=($(grep "set -g @plugin" "$TMUX_CONF" |


### PR DESCRIPTION
Default `bash` in macos doesn't provide `mapfile` by default, so there is must be a compatibility check as it exists for `iSH`