### PR TITLE
feat: add back tick as special character

### DIFF
--- a/scripts/utils/tmux.sh
+++ b/scripts/utils/tmux.sh
@@ -307,6 +307,9 @@ tmux_escape_special_chars() {
         \\)
             tesc_esc_str="${tesc_esc_str}\\\\"
             ;;
+        \`)
+            tesc_esc_str="${tesc_esc_str}\\\`"
+            ;;
         \")
             tesc_esc_str="${tesc_esc_str}\\\""
             ;;


### PR DESCRIPTION
I set ` as trigger key in my tmux.conf, but it does not work. so I add this key as special char, now it works

now it works.