### PR TITLE
fix: avoid fixing the home path of _log_file if it is empty

### DIFF
--- a/scripts/utils/tmux.sh
+++ b/scripts/utils/tmux.sh
@@ -310,8 +310,11 @@ tmux_get_plugin_options() { # cache references
         #  If a debug logfile has been set, the tmux setting will be ignored.
         # log_it "tmux will read cfg_log_file"
         tmux_get_option _log_file "@menus_log_file" "$default_log_file"
-        # Handle the case of ~ or $HOME being wrapped in single quotes in tmux.conf
-        fix_home_path cfg_log_file "$_log_file"
+
+        if [ -n "$_log_file" ]; then
+            # Handle the case of ~ or $HOME being wrapped in single quotes in tmux.conf
+            fix_home_path cfg_log_file "$_log_file"
+        fi
     }
 
     #


### PR DESCRIPTION
The `fix_home_path` function is throwing an error because when `@menus_log_file` and `default_log_file` are not defined, `_log_file` is empty.