### PR TITLE
v2.2.4

### DIFF
--- a/.olint.conf
+++ b/.olint.conf
@@ -2,6 +2,11 @@
 # This is sourced. Fake bang-path to help editors and linters
 # shellcheck disable=SC2034,SC2154
 
+skip_linters+=(
+    pymarkdown
+)
+
+
 # Patterns to exclude from linting, anything starting with this will be excluded
 excluded_prefixes+=(
     cache/

--- a/.olint.conf
+++ b/.olint.conf
@@ -22,14 +22,14 @@ excludes+=(
 # These files cause shellcheck to use vast amounts of RAM.
 # Skip them on limited systems, to avoid olint crashing.
 excludes+=(
-    items/currencies.sh
-    items/hints/choose-buffer.sh
-    items/hints/choose-client.sh
-    items/hints/choose-tree.sh
-    items/hints/customize-mode.sh
-    items/missing_keys.sh
-    scripts/relocate_pane.sh
-    scripts/relocate_window.sh
+    # items/currencies.sh
+    # items/hints/choose-buffer.sh
+    # items/hints/choose-client.sh
+    # items/hints/choose-tree.sh
+    # items/hints/customize-mode.sh
+    # items/missing_keys.sh
+    # scripts/relocate_pane.sh
+    # scripts/relocate_window.sh
 )
 #     ;;
 # *) ;;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- tmux_error_handler_assign() - streamlined for performance and added inline comments
+
+---
+
 ## [2.2.3] - 2025-04-28
 
 ### Added
@@ -14,7 +22,7 @@ All notable changes to this project will be documented here.
 
 - Changed titles of some menus to better reflect current placement
 - Removed a relative path expander, no longer needed and caused some external
-menu actions to fail
+  menu actions to fail
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented here.
 - moved definition of TMUX_BIN to scripts/utils/define_tmux_bin.sh in order to ensure
   sockets will always be used to minimize risk for collisions if an inner tmux uses
   this plugin
+- scripts/utils/std_alone_log.sh - Tries to pick up current log_file if defined
+  otherwise logs to /dev/stderr
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to this project will be documented here.
 - Added run_if_found() - makes code cleaner
 - Bug fix: fix_home_path() - Now correctly handles the odd behaviour of tmux 3.4
 - moved all profiling init to dbg_profiling.sh
+- Bug fix: scripts/update_custom_inventory.sh - ensure main menu is cleared if
+  custom items are removed, to ensure main menu stops offering custom menus
 
 ## [2.2.3] - 2025-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ All notable changes to this project will be documented here.
 - menu_generate_part() - abort early for empty parts
 - static_files_reduction() - simplified
 - Improved error detection when parsing and displaying menus
-- sort_menu_items() & cache_read_menu_items() - simplified code, slight performance boost
+- sort_menu_items() -> get_menu_items_sorted()
+- get_menu_items_sorted() & cache_read_menu_items() - simplified code, slight performance boost
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented here.
 - Bug fix: verify_menu_runable() - escape ' in order to display errors in menu code
 - tmux_error_handler_assign() - streamlined for performance and added inline comments
 - menu_generate_part() - abort early for empty parts
+- static_files_reduction() - simplified
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented here.
 - menu_generate_part() - abort early for empty parts
 - static_files_reduction() - simplified
 - Improved error detection when parsing and displaying menus
+- sort_menu_items() & cache_read_menu_items() - simplified code, slight performance boost
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable changes to this project will be documented here.
 
 ### Changed
 
+- Fixed a bug forgetting to check if cache is active in dialog_handling.sh:handle_dynamic()
 - tmux_error_handler_assign() - streamlined for performance and added inline comments
+- menu_generate_part() - abort early for empty parts
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+### Added
+
+- Created a list in TODO over the cached process, in order to see what can be optimized
+
 ### Changed
 
 - Fixed a bug forgetting to check if cache is active in dialog_handling.sh:handle_dynamic()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,7 @@ All notable changes to this project will be documented here.
 - menu_parse() - optimized processing
 - Added run_if_found() - makes code cleaner
 - Bug fix: fix_home_path() - Now correctly handles the odd behaviour of tmux 3.4
-
----
+- moved all profiling init to dbg_profiling.sh
 
 ## [2.2.3] - 2025-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented here.
 - sort_menu_items() -> get_menu_items_sorted()
 - get_menu_items_sorted() & cache_read_menu_items() - simplified code, slight performance boost
 - menu_parse() - optimized processing
+- Added run_if_found() - makes code cleaner
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable changes to this project will be documented here.
 ### Changed
 
 - 'Move pane' & 'Move Window' - Corrected check when pane is marked in another context
-- Fixed a bug forgetting to check if cache is active in dialog_handling.sh:handle_dynamic()
+- Bug fix: forgetting to check if cache is active in dialog_handling.sh:handle_dynamic()
+- Bug fix: verify_menu_runable() - escape ' in order to display errors in menu code
 - tmux_error_handler_assign() - streamlined for performance and added inline comments
 - menu_generate_part() - abort early for empty parts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented here.
 - get_menu_items_sorted() & cache_read_menu_items() - simplified code, slight performance boost
 - menu_parse() - optimized processing
 - Added run_if_found() - makes code cleaner
+- Bug fix: fix_home_path() - Now correctly handles the odd behaviour of tmux 3.4
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ All notable changes to this project will be documented here.
 
 - Created a list in TODO over the cached process, in order to see what can be optimized
 - time_span(org_time) - sets t_time_span to time since org_time
-- moved definition of TMUX_BIN to scripts/utils/define_tmux_bin.sh in order to ensure
+- copied definition of TMUX*BIN to scripts/utils/define_tmux_bin.sh in order to ensure
   sockets will always be used to minimize risk for collisions if an inner tmux uses
-  this plugin
+  this plugin in stdalone tools, like external_dialog*\*
 - scripts/utils/std_alone_log.sh - Tries to pick up current log_file if defined
   otherwise logs to /dev/stderr
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented here.
 ### Added
 
 - Created a list in TODO over the cached process, in order to see what can be optimized
+- time_span(org_time) - sets t_time_span to time since org_time
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented here.
 - Improved error detection when parsing and displaying menus
 - sort_menu_items() -> get_menu_items_sorted()
 - get_menu_items_sorted() & cache_read_menu_items() - simplified code, slight performance boost
+- menu_parse() - optimized processing
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented here.
 - tmux_error_handler_assign() - streamlined for performance and added inline comments
 - menu_generate_part() - abort early for empty parts
 - static_files_reduction() - simplified
+- Improved error detection when parsing and displaying menus
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,35 +4,38 @@ All notable changes to this project will be documented here.
 
 ---
 
-## [Unreleased]
+## [2.2.4] - 2025-05-09
 
 ### Added
 
-- Created a list in TODO over the cached process, in order to see what can be optimized
 - time_span(org_time) - sets t_time_span to time since org_time
 - copied definition of TMUX*BIN to scripts/utils/define_tmux_bin.sh in order to ensure
   sockets will always be used to minimize risk for collisions if an inner tmux uses
-  this plugin in stdalone tools, like external_dialog*\*
-- scripts/utils/std_alone_log.sh - Tries to pick up current log_file if defined
-  otherwise logs to /dev/stderr
+  this plugin in stdalone tools, like `external_dialog*\*`
+- scripts/utils/std*alone_log.sh - Tries to pick up current log_file if defined
+  otherwise logs to /dev/stderr, used by external tools that don't load the entire
+  environment like `external_dialog*\*`
 
 ### Changed
 
-- 'Move pane' & 'Move Window' - Corrected check when pane is marked in another context
+- Bug fix: fix_home_path() - Now correctly handles the odd behaviour of tmux 3.4
 - Bug fix: forgetting to check if cache is active in dialog_handling.sh:handle_dynamic()
 - Bug fix: verify_menu_runable() - escape ' in order to display errors in menu code
-- tmux_error_handler_assign() - streamlined for performance and added inline comments
-- menu_generate_part() - abort early for empty parts
-- static_files_reduction() - simplified
-- Improved error detection when parsing and displaying menus
-- sort_menu_items() -> get_menu_items_sorted()
-- get_menu_items_sorted() & cache_read_menu_items() - simplified code, slight performance boost
-- menu_parse() - optimized processing
-- Added run_if_found() - makes code cleaner
-- Bug fix: fix_home_path() - Now correctly handles the odd behaviour of tmux 3.4
-- moved all profiling init to dbg_profiling.sh
 - Bug fix: scripts/update_custom_inventory.sh - ensure main menu is cleared if
   custom items are removed, to ensure main menu stops offering custom menus
+
+- menu_parse() - optimized processing
+- menu_generate_part() - abort early for empty parts
+- tmux_error_handler_assign() - streamlined for performance and added inline comments
+- get_menu_items_sorted() & cache_read_menu_items() - simplified code, slight performance boost
+- Added run_if_found() - makes code cleaner
+- Improved error detection when parsing and displaying menus
+- 'Move pane' & 'Move Window' - Corrected check when pane is marked in another context
+- static_files_reduction() - simplified
+- sort_menu_items() -> get_menu_items_sorted()
+- moved all profiling init to dbg_profiling.sh
+
+---
 
 ## [2.2.3] - 2025-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented here.
 
 ### Changed
 
+- 'Move pane' & 'Move Window' - Corrected check when pane is marked in another context
 - Fixed a bug forgetting to check if cache is active in dialog_handling.sh:handle_dynamic()
 - tmux_error_handler_assign() - streamlined for performance and added inline comments
 - menu_generate_part() - abort early for empty parts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented here.
 
 - Created a list in TODO over the cached process, in order to see what can be optimized
 - time_span(org_time) - sets t_time_span to time since org_time
+- moved definition of TMUX_BIN to scripts/utils/define_tmux_bin.sh in order to ensure
+  sockets will always be used to minimize risk for collisions if an inner tmux uses
+  this plugin
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ The best way to send feedback is to file an
 ## Thanks to
 
 - [cmon1701](https://github.com/cmon1701) For notifying me that the plugin listing
-  used hardcoded path assumptions - Addressed i release 2.1.3
+  used hardcoded path assumptions - Addressed in release 2.1.3
 - [sumskyi](https://github.com/sumskyi) for notifying me that the boolean check
   error message for invalid values lacked the significant info about what variable
   contained the incorrect value. Addressed in release 2.0.2

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6,20 +6,20 @@ These should be as performant as possible!
 
 - prepare_menu
 
-  - set_menu_env_variables
-    - relative_path
-  - cache_static_content
-    - get_mtime
+  - set_menu_env_variables - checked
+    - relative_path - checked
+  - cache_static_content - checked
+    - get_mtime - checked
   - handle_dynamic - these are always run uncached, so performance is a premium!
     - is_function_defined
     - dynamic_content - various but commonly include
-      - menu_generate_part +++ <- investigate!
-      - tmux_error_handler_assign ++ <- investigate!
+      - menu_generate_part +++ - checked
+      - tmux_error_handler_assign ++ - checked
         - validate_varname - checked
-      - display_commands_toggle - only used to display commands, so not a priority
+      - display_commands_toggle - checked
       - tmux_vers_check - checked
-  - get_menu_items_sorted
-    - cache_read_menu_items
+  - get_menu_items_sorted - checked
+    - cache_read_menu_items - checked
 
 - display_menu - checked
   - safe_now - checked

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -22,9 +22,9 @@ These should be as performant as possible!
     - generate_menu_items_in_sorted_order
   - verify_menu_runable
 
-- display_menu
-  - safe_now
-  - ensure_menu_fits_on_screen
+- display_menu - checked
+  - safe_now - checked
+  - ensure_menu_fits_on_screen - checked
 
 ## tmux 3.4
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -19,8 +19,7 @@ These should be as performant as possible!
       - display_commands_toggle - only used to display commands, so not a priority
       - tmux_vers_check - checked
   - sort_menu_items
-    - generate_menu_items_in_sorted_order
-  - verify_menu_runable
+    - cache_read_menu_items
 
 - display_menu - checked
   - safe_now - checked

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,30 +1,5 @@
 # Plan
 
-## Workflow cached menu
-
-These should be as performant as possible!
-
-- prepare_menu
-
-  - set_menu_env_variables - checked
-    - relative_path - checked
-  - cache_static_content - checked
-    - get_mtime - checked
-  - handle_dynamic - these are always run uncached, so performance is a premium!
-    - is_function_defined
-    - dynamic_content - various but commonly include
-      - menu_generate_part +++ - checked
-      - tmux_error_handler_assign ++ - checked
-        - validate_varname - checked
-      - display_commands_toggle - checked
-      - tmux_vers_check - checked
-  - get_menu_items_sorted - checked
-    - cache_read_menu_items - checked
-
-- display_menu - checked
-  - safe_now - checked
-  - ensure_menu_fits_on_screen - checked
-
 ## tmux 3.4
 
 - @menus_config_file - when HOME is expanded in some cases there are glitches

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -18,7 +18,7 @@ These should be as performant as possible!
         - validate_varname - checked
       - display_commands_toggle - only used to display commands, so not a priority
       - tmux_vers_check - checked
-  - sort_menu_items
+  - get_menu_items_sorted
     - cache_read_menu_items
 
 - display_menu - checked

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,9 +1,5 @@
 # Plan
 
-## tmux 3.4
-
-- @menus_config_file - when HOME is expanded in some cases there are glitches
-
 ## Styling
 
 - quotes are not handled correctly for `@menus_format_title`

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,39 @@
 # Plan
 
+## Workflow cached menu
+
+These should be as performant as possible!
+
+- prepare_menu
+
+  - set_menu_env_variables
+    - relative_path
+  - cache_static_content
+    - get_mtime
+  - handle_dynamic - these are always run uncached, so performance is a premium!
+    - is_function_defined
+    - dynamic_content - various but commonly include
+      - menu_generate_part +++ <- investigate!
+      - tmux_error_handler_assign ++ <- investigate!
+        - validate_varname - checked
+      - display_commands_toggle - only used to display commands, so not a priority
+      - tmux_vers_check - checked
+  - sort_menu_items
+    - generate_menu_items_in_sorted_order
+  - verify_menu_runable
+
+- display_menu
+  - safe_now
+  - ensure_menu_fits_on_screen
+
+## tmux 3.4
+
+- @menus_config_file - when HOME is expanded in some cases there are glitches
+
+## Styling
+
+- quotes are not handled correctly for `@menus_format_title`
+
 ## WhipTail
 
 - menu_reload is not working, so disabled
@@ -11,3 +45,7 @@ toggle not working
 ## Pane titles
 
 Add items, enable/disable show pane titles
+
+## Inspect if this works as intended
+
+has_lf_not_at_end

--- a/items/external_tools/dropbox.sh
+++ b/items/external_tools/dropbox.sh
@@ -28,7 +28,6 @@ static_content() {
 
     [ -z "$(command -v dropbox)" ] && error_msg_safe "dropbox bin not found!"
 
-    log_it "><> dropbox.sh menu_reload [$menu_reload]"
     set -- \
         0.0 M Left "Back to Extras     $nav_prev" extras.sh \
         0.0 M Home "Back to Main menu  $nav_home" main.sh

--- a/items/help/help_summary.sh
+++ b/items/help/help_summary.sh
@@ -8,7 +8,7 @@
 #   General Help
 #
 
-calculate_about_box_content() {
+gather_about_box_variables() {
     cd "$D_TM_BASE_PATH" || error_msg "Failed to cd into $D_TM_BASE_PATH"
 
     td_pull="$(git log -1 --format=%cd --date=iso)"
@@ -50,7 +50,7 @@ dynamic_content() {
         0.0 M Home "Back to Main menu      $nav_home" main.sh
     menu_generate_part 1 "$@"
 
-    calculate_about_box_content
+    gather_about_box_variables
     set -- # since it is unclear what item is first, do a init here and then just add
     [ -n "$vers_no" ] && set -- "$@" 0.0 T "-#[nodim]      Version: $vers_no"
     [ -n "$td_vers" ] && set -- "$@" 0.0 T "-#[nodim] Vers release: $td_vers"

--- a/items/main.sh
+++ b/items/main.sh
@@ -39,7 +39,7 @@ static_content() {
         0.0 M A "Advanced options   $nav_next" advanced.sh \
         0.0 M E "Extras             $nav_next" extras.sh
     menu_generate_part 1 "$@"
-    $cfg_display_cmds && display_commands_toggle 2
+    $cfg_display_cmds && display_commands_toggle 2 # give this its own menu part idx
 
     set -- \
         0.0 S \
@@ -61,7 +61,6 @@ static_content() {
         "$d_help/help_summary.sh $0"
 
     menu_generate_part 3 "$@"
-
 }
 
 #===============================================================

--- a/items/main.sh
+++ b/items/main.sh
@@ -9,7 +9,6 @@
 #
 
 static_content() {
-    # shellcheck disable=SC2154
     rld_cmd="command-prompt -I '$cfg_tmux_conf' -p 'Source file:' \
         'run-shell \"$d_scripts/reload_conf.sh %% $reload_in_runshell\"'"
 

--- a/items/pane_move.sh
+++ b/items/pane_move.sh
@@ -23,7 +23,10 @@ dynamic_content() {
     else
         set -- # clear params
     fi
-    menu_generate_part 4 "$@" # needs to be generated even if empty, to clear this item
+
+    # Needs to be generated even if empty, in order to clear this item if it had
+    # content last time this menu was displayed
+    menu_generate_part 4 "$@"
 }
 
 static_content() {
@@ -33,9 +36,16 @@ static_content() {
     menu_generate_part 1 "$@"
     $cfg_display_cmds && display_commands_toggle 2
 
+    #
+    # In principle, if this was moved into segment 1 there would be one less
+    # cache part to handle, so would be more efficient. However this minuscule speed
+    # gain would cause the command toggle to be displayed outside the first menu segment
+    # and thus create an inconsistent look. So in practical terms its just not
+    # worth it. But I do agree that it looks pretty silly to have a separate
+    # cache file that only contains: ""
+    #
     set -- \
         1.7 S
-
     menu_generate_part 3 "$@"
 
     set -- \
@@ -50,12 +60,10 @@ static_content() {
             1.7 M K "Key hints - Move to other $nav_next" \
             "$d_hints/choose-tree.sh $0"
     }
-
     set -- "$@" \
         0.0 S \
         1.7 M H "Help, Move to other    $nav_next" \
         "$d_help/help_pane_move.sh $0"
-
     menu_generate_part 5 "$@"
 }
 

--- a/items/pane_move.sh
+++ b/items/pane_move.sh
@@ -9,17 +9,21 @@
 #
 
 dynamic_content() {
-    # clear params content
-    set --
-    tmux_vers_check 3.0 && {
-        # marking a pane is an ancient feature, but pane_marked came at 3.0
-        $TMUX_BIN display-message -p \
-            '#{&&:#{pane_marked_set},#{!=:#{pane_marked},1}}' | grep -q 1 && {
-            set -- \
-                3.0 C m "Swap current pane with marked" "swap-pane $menu_reload"
-        }
-    }
-    menu_generate_part 4 "$@" # needs to be generated even if empty, to keep an item 2
+    # marking a pane is an ancient feature, but pane_marked came at 3.0
+    tmux_vers_check 3.0 || return
+
+    $all_helpers_sourced || source_all_helpers "pane_move:dynamic_content()"
+    tmux_error_handler_assign other_pane_marked display-message \
+        -p '#{&&:#{pane_marked_set},#{!=:#{pane_marked},1}}'
+
+    # shellcheck disable=SC2154
+    if [ "$other_pane_marked" = 1 ]; then
+        set -- \
+            3.0 C m "Swap current pane with marked" "swap-pane $menu_reload"
+    else
+        set -- # clear params
+    fi
+    menu_generate_part 4 "$@" # needs to be generated even if empty, to clear this item
 }
 
 static_content() {

--- a/items/window_move.sh
+++ b/items/window_move.sh
@@ -9,17 +9,24 @@
 #
 
 dynamic_content() {
-    # Things that change dependent on various states
+    # marking a pane is an ancient feature, but pane_marked came at 3.0
+    tmux_vers_check 3.0 || return
 
-    $all_helpers_sourced || source_all_helpers "window_move:dynamic_content()()"
-    tmux_error_handler_assign other_pane_is_marked display -p '#{?pane_marked_set,yes,}'
+    $all_helpers_sourced || source_all_helpers "window_move:dynamic_content()"
 
-    if [ -n "$other_pane_is_marked" ]; then
+    tmux_error_handler_assign this_win_id display-message -p '#{window_id}'
+    tmux_error_handler_assign pane_marked_status list-panes -a \
+        -F '#{pane_marked} #{window_id}'
+
+    # shellcheck disable=SC2154
+    s_found="$(echo "$pane_marked_status" | grep '1 ' | grep -v "$this_win_id")"
+    if [ -n "$s_found" ]; then
         set -- \
-            0.0 T "-#[nodim]Swap current window with window" \
-            0.0 C s " containing marked pane" swap-window
+            3.0 T "-#[nodim]Swap current window with window" \
+            3.0 C s " containing marked pane" swap-window
+    else
+        set --
     fi
-
     menu_generate_part 4 "$@"
 }
 

--- a/items/window_move.sh
+++ b/items/window_move.sh
@@ -35,7 +35,7 @@ static_content() {
         0.0 M Left "Back to Handling Window  $nav_prev" windows.sh \
         0.0 M Home "Back to Main menu        $nav_home" main.sh
     menu_generate_part 1 "$@"
-    $cfg_display_cmds && display_commands_toggle 2
+    $cfg_display_cmds && display_commands_toggle 2 # give this its own menu part idx
 
     set -- \
         0.0 S

--- a/scripts/dialog_handling.sh
+++ b/scripts/dialog_handling.sh
@@ -332,10 +332,10 @@ menu_parse() {
                 keep_cmd=false
             fi
 
-            verify_menu_key "$key" "tmux command: $cmd"
-
             # first extract the variables, then  if it shouldn't be used move on
             ! tmux_vers_check "$min_vers" && continue
+
+            verify_menu_key "$key" "tmux command: $cmd"
 
             [ -n "$menu_debug" ] && debug_print "key[$key] label[$label] command[$cmd]"
 
@@ -367,10 +367,10 @@ menu_parse() {
             cmd="$1"
             shift
 
-            verify_menu_key "$key" "external command: $cmd"
-
             # first extract the variables, then  if it shouldn't be used move on
             ! tmux_vers_check "$min_vers" && continue
+
+            verify_menu_key "$key" "external command: $cmd"
 
             [ -n "$menu_debug" ] && debug_print "key[$key] label[$label] command[$cmd]"
 
@@ -391,16 +391,19 @@ menu_parse() {
             menu="$1"
             shift
 
-            verify_menu_key "$key" "$menu"
-
             # first extract the variables, then  if it shouldn't be used move on
             ! tmux_vers_check "$min_vers" && continue
+
+            verify_menu_key "$key" "$menu"
 
             #
             #  If menu is not full PATH, assume it to be a tmux-menus
             #  item
             #
-            echo "$menu" | grep -vq / && menu="$d_items/$menu"
+            case $menu in
+            */*) ;;
+            *) menu="$d_items/$menu" ;;
+            esac
 
             [ -n "$menu_debug" ] && debug_print "key[$key] label[$label] menu[$menu]"
 
@@ -692,7 +695,7 @@ cache_static_content() {
         # Cache is missing or obsolete, regenerate it
         # log_it "  regenerate cache for: $d_menu_cache"
         $all_helpers_sourced || {
-            source_all_helpers "cache_static_content() - cache error"
+            source_all_helpers "cache_static_content() - cache regeneration"
         }
         safe_remove "$d_menu_cache"
         mkdir -p "$d_menu_cache" || error_msg_safe "Failed to create: $d_menu_cache"

--- a/scripts/dialog_handling.sh
+++ b/scripts/dialog_handling.sh
@@ -531,22 +531,22 @@ set_menu_env_variables() {
 }
 
 static_files_reduction() {
+    #
     # if only static content was generated, compact all parts into one
     # for quicker cache loading
+    #
+    # this is not performance critical
+    #
     $dynamic_content_found && {
         error_msg "static_files_reduction() called when dynamic content was generated"
     }
     # log_it "static_files_reduction()"
-    _items="$(find "$d_menu_cache" -maxdepth 1 -type f | wc -l)"
-
-    [ "$_items" -gt 1 ] && {
-        sort_menu_items
-        find "$d_menu_cache" -maxdepth 1 -type f | while IFS= read -r f_name; do
-            safe_remove "$f_name"
-            echo "$menu_items" >"$d_menu_cache/1"
-        done
-        unset menu_items # clear it
-    }
+    cache_read_menu_items
+    for f_name in "$d_menu_cache"/*; do
+        [ -d "$f_name" ] && continue
+        rm "$f_name" || error_msg "static_files_reduction() - failed to remove: $f_name"
+    done
+    echo "$menu_items" >"$d_menu_cache/1"
 }
 
 cache_static_content() {

--- a/scripts/dialog_handling.sh
+++ b/scripts/dialog_handling.sh
@@ -916,7 +916,6 @@ display_menu() {
     else
         safe_now dh_t_start
         eval "$menu_items"
-
         ensure_menu_fits_on_screen
     fi
 }

--- a/scripts/dialog_handling.sh
+++ b/scripts/dialog_handling.sh
@@ -307,6 +307,7 @@ menu_parse() {
     #
     # log_it "mennu_parse()"
 
+    menu_items=""
     [ "$menu_idx" -eq 1 ] && {
         # set prefix for item 1
         if $cfg_use_whiptail; then

--- a/scripts/dialog_handling.sh
+++ b/scripts/dialog_handling.sh
@@ -779,13 +779,11 @@ $idx	$gmi_body"
     )"
 }
 
-sort_menu_items() {
-    # log_it "sort_menu_items()"
+get_menu_items_sorted() {
+    # log_it "get_menu_items_sorted()"
     if $cfg_use_cache; then
         cache_read_menu_items
     else
-        # _s="[dialog_handling] sort_menu_items()"
-        # _s="$_s - calling: sort_uncached_menu_items"
         sort_uncached_menu_items
     fi
 }
@@ -813,7 +811,7 @@ prepare_menu() {
     $static_cache_updated && ! $dynamic_content_found && static_files_reduction
 
     # 3 - Gather each item in correct order
-    sort_menu_items
+    get_menu_items_sorted
 }
 
 #---------------------------------------------------------------

--- a/scripts/dialog_handling.sh
+++ b/scripts/dialog_handling.sh
@@ -710,7 +710,7 @@ handle_dynamic() {
         wt_actions_static="$wt_actions"
         wt_actions=""
         is_dynamic_content=true
-        mkdir -p "$d_menu_cache" # needed if menu is purely dynamic
+        $cfg_use_cache && mkdir -p "$d_menu_cache" # needed if menu is purely dynamic
         dynamic_content
         is_dynamic_content=false
         wt_actions="$wt_actions_static"

--- a/scripts/dialog_handling.sh
+++ b/scripts/dialog_handling.sh
@@ -667,20 +667,36 @@ verify_menu_runable() {
         _mnu_first="${TMUX_BIN%% *}"
     fi
     [ "$_actual_first" = "$_mnu_first" ] || {
-        msg="The processed menu should start with a menu handler."
-        msg="$msg\nIn the current environment this was expected:"
-        msg="$msg\n\n  $_mnu_first"
-        msg="$msg\n\nThis was found:"
-        msg="$msg\n\n  $_actual_first"
-        msg="$msg\n\nWas no part 1 created?\n"
-        msg="$msg\nThe menu handler and other menu definitions like title"
-        msg="$msg and styling\nare prepended to the part defined by:"
-        msg="$msg\n\n  menu_generate_part 1 \""'$@'"\"\n"
-        msg="$msg\nGenerated menu:\n"
+        escaped_menu_items="$(echo "$menu_items" | sed "s/\'/[\"]/g")"
 
-        # filter ; ini order not to execute when displaying the error msg
-        escaped="$(printf '%s' "$menu_items" | sed 's/;//g')"
-        error_msg_safe "$msg\n$escaped"
+        #region tmux error msg
+        error_msg_safe "$(
+            cat <<EOF
+The processed menu should start with a menu handler.
+In the current environment this was expected:
+
+  $_mnu_first
+
+This was found:
+
+  $_actual_first
+
+Was no part 1 created?
+
+The menu handler and other menu definitions like title and styling
+are prepended to the part created by:
+
+menu_generate_part 1 "\$@"
+
+Generated menu below - single quotes have been changed to: [\"],
+otherwise the commands can not be displayed here
+
+-----   menu start   -----
+$escaped_menu_items
+-----    menu end    -----
+EOF
+        )"
+        #endregion
     }
 }
 

--- a/scripts/dialog_handling.sh
+++ b/scripts/dialog_handling.sh
@@ -97,16 +97,24 @@ menu_generate_part() {
     # Generate one menu segment
     # log_it "menu_generate_part($1)"
 
+    menu_idx="$1"
+    $cfg_use_cache && f_cache_file="$d_menu_cache/$menu_idx"
+
+    # needs to be set even if this is an empty dynamic menu to prevent
+    # static_files_reduction() from running
     $is_dynamic_content && dynamic_content_found=true
+
+    [ -z "$2" ] && {
+        # no params clear cache file if any
+        # log_it "><> menu_generate_part() idx:$menu_idx - empty"
+        $cfg_use_cache && rm -f "$f_cache_file"
+        return
+    }
+
+    shift # get rid of the idx param
     $all_helpers_sourced || source_all_helpers "menu_generate_part()"
 
-    menu_idx="$1"
-    shift # get rid of the idx
-
-    $cfg_use_cache && f_cache_file="$d_menu_cache/$menu_idx"
-    # log_it "><> menu_generate_part($menu_idx) using cache: $f_cache_file"
     menu_parse "$@"
-
     $cfg_use_whiptail && update_wt_actions
 }
 

--- a/scripts/dialog_handling.sh
+++ b/scripts/dialog_handling.sh
@@ -725,7 +725,7 @@ handle_dynamic() {
 
 cache_read_menu_items() {
     #
-    # Exports: menu_items
+    # Provides: menu_items
     #
     menu_items=""
     for f_name in "$d_menu_cache"/*; do

--- a/scripts/dialog_handling.sh
+++ b/scripts/dialog_handling.sh
@@ -844,11 +844,10 @@ ensure_menu_fits_on_screen() {
     #  would do.
     #
     # Display time menu was shown
-    safe_now
-    disp_time="$(echo "$t_now - $dh_t_start" | bc)"
+    time_span "$dh_t_start"
 
     # log_it "ensure_menu_fits_on_screen() Menu $bn_current_script - Display time:  $disp_time ($t_minimal_display_time)"
-    [ "$(echo "$disp_time < $t_minimal_display_time" | bc)" -eq 1 ] && {
+    [ "$(echo "$t_time_span < $t_minimal_display_time" | bc)" -eq 1 ] && {
         $all_helpers_sourced || {
             source_all_helpers "ensure_menu_fits_on_screen()  short display, give warning"
         }
@@ -867,19 +866,17 @@ ensure_menu_fits_on_screen() {
         elif [ -n "$menu_width" ]; then
             _s="$f_menu_rel: Width required: $menu_width"
         else
-            # log_it "display time was: $disp_time"
-            _s="$f_menu_rel: Screen might be too small - menu closed after $disp_time"
+            # log_it "display time was: $t_time_span"
+            _s="$f_menu_rel: Screen might be too small - menu closed after $t_time_span"
         fi
         error_msg_safe "$_s"
     }
 }
 
 clear_prep_disp_status() {
-    safe_now
+    time_span "$t_show_cmds"
     display_command_label
-    log_it "$(relative_path "$0") - Preparing $_lbl took: $(
-        echo "$t_now - $t_show_cmds" | bc
-    )s"
+    log_it "$(relative_path "$0") - Preparing $_lbl took: ${t_time_span}s"
 
     if tmux_vers_check 3.2; then
         tmux_error_handler display-message -d 1 ""
@@ -902,11 +899,10 @@ display_menu() {
     [ -n "$cfg_log_file" ] && {
         # If logging is disabled - no point in generating this log msg
 
-        safe_now
-        _t="$(echo "$t_now - $t_script_start" | bc)"
+        time_span "$t_script_start"
 
         _m="Menu $(relative_path "$0")"
-        _m="$_m - processing time:  $_t"
+        _m="$_m - processing time:  $t_time_span"
         log_it_minimal "$_m"
     }
 

--- a/scripts/dialog_handling.sh
+++ b/scripts/dialog_handling.sh
@@ -106,7 +106,6 @@ menu_generate_part() {
 
     [ -z "$2" ] && {
         # no params clear cache file if any
-        # log_it "><> menu_generate_part() idx:$menu_idx - empty"
         $cfg_use_cache && rm -f "$f_cache_file"
         return
     }
@@ -295,7 +294,7 @@ menu_parse() {
     #  we first identify all the params used by the different options,
     #  only then can we continue if the min_vers does not match running tmux
     #
-    # log_it "><> mennu_parse()"
+    # log_it "mennu_parse()"
 
     [ "$menu_idx" -eq 1 ] && {
         # set prefix for item 1
@@ -1157,6 +1156,13 @@ esac
 #  cache handling.
 #
 menu_debug="" # Set to 1 to use echo 2 to use log_it
+
+# Useful when debugging to keep each menu generation process separate
+# log_it
+# log_it
+# log_it
+# log_it
+# log_it
 
 prepare_menu
 display_menu

--- a/scripts/dialog_handling.sh
+++ b/scripts/dialog_handling.sh
@@ -70,6 +70,7 @@ is_function_defined() {
 }
 
 update_wt_actions() {
+    # log_it "update_wt_actions()"
     if $cfg_use_cache; then
         [ "$menu_idx" -eq 1 ] && {
             # clear menu actions
@@ -716,7 +717,24 @@ handle_dynamic() {
     }
 }
 
-generate_menu_items_in_sorted_order() {
+cache_read_menu_items() {
+    #
+    # Exports: menu_items
+    #
+    menu_items=""
+    for f_name in "$d_menu_cache"/*; do
+        [ -d "$f_name" ] && continue # most likely a wt_actions/
+
+        # Read the content of the file and append it to the menu_items variable
+        if [ -z "$menu_items" ]; then
+            menu_items="$(cat "$f_name")"
+        else
+            menu_items="$menu_items $(cat "$f_name")"
+        fi
+    done
+}
+
+sort_uncached_menu_items() {
     #
     # Since dynamic_content is generated after static_content, it can't be assumed
     # that the menu fragments were generated in proper order, in addition the
@@ -727,6 +745,8 @@ generate_menu_items_in_sorted_order() {
     # together, leads to this rather hackish in-memory implementation of sorting
     # the uncached_menu clearly lots of room for improvement...
     #
+    # log_it "sort_uncached_menu_items()"
+
     gmi_entries=""
 
     gmi_rest="$uncached_menu"
@@ -762,20 +782,11 @@ $idx	$gmi_body"
 sort_menu_items() {
     # log_it "sort_menu_items()"
     if $cfg_use_cache; then
-        for f_name in "$d_menu_cache"/*; do
-            # log_it "><> sort_menu_items() - processing: $f_name"
-
-            # skip special files
-            b_name=${f_name##*/} # basename equiv
-            [ "${#b_name}" -gt "2" ] && continue
-
-            # Read the content of the file and append it to the menu_items variable
-            menu_items="$menu_items $(cat "$f_name")"
-        done
+        cache_read_menu_items
     else
         # _s="[dialog_handling] sort_menu_items()"
-        # _s="$_s - calling: generate_menu_items_in_sorted_order"
-        generate_menu_items_in_sorted_order
+        # _s="$_s - calling: sort_uncached_menu_items"
+        sort_uncached_menu_items
     fi
 }
 

--- a/scripts/dialog_handling.sh
+++ b/scripts/dialog_handling.sh
@@ -1103,7 +1103,7 @@ display_commands_toggle() {
         echo
         echo "$msg"
         echo
-    )
+    ) >/dev/stderr
     exit 1
 }
 

--- a/scripts/external_dialog_handle.sh
+++ b/scripts/external_dialog_handle.sh
@@ -6,24 +6,28 @@
 #  Part of https://github.com/jaclu/tmux-menus
 #
 #  This is run in the current pane, so job control is available
-#  Displays main menu
-#  Since this doesn't really need the normal env, do things directly without
-#  any sourcing.
+#
+#  I have tried to supply params for what menu to start but so far not succeeded
+#  in poviding params to this script, neither via cmd params or env variable
+#  So for now it can only trigger the main menu
 #
 
-[ -z "$TMUX_BIN" ] && TMUX_BIN="tmux"
+#  Full path to tmux-menus plugin
+D_TM_BASE_PATH="$(dirname -- "$(dirname -- "$(realpath "$0")")")"
 
-if [ -n "$TMUX_MENUS_EXTERNAL_MENU" ]; then
-    $TMUX_MENUS_EXTERNAL_MENU
-else
-    #  Full path to tmux-menux plugin
-    D_TM_BASE_PATH="$(dirname -- "$(dirname -- "$(realpath "$0")")")"
+f_std_alone_log="$D_TM_BASE_PATH"/scripts/utils/std_alone_log.sh
+msg_prefix="external_dialog_handle.sh -"
 
-    # Run the main script
-    "$D_TM_BASE_PATH"/items/main.sh
-fi
+$f_std_alone_log "$msg_prefix - will run main menu"
+
+"$D_TM_BASE_PATH"/items/main.sh
 
 #
 #  If a process was suspended, bring it back into fore-ground
 #
-pgrep -P "$PPID" | grep -qv "$$" && $TMUX_BIN send-keys fg Enter
+pgrep -P "$PPID" | grep -qv "$$" && {
+    $f_std_alone_log "$msg_prefix - will restore suspended app"
+    . "$D_TM_BASE_PATH"/scripts/utils/define_tmux_bin.sh
+    $TMUX_BIN send-keys fg Enter
+}
+$f_std_alone_log "$msg_prefix done"

--- a/scripts/external_dialog_trigger.sh
+++ b/scripts/external_dialog_trigger.sh
@@ -7,19 +7,12 @@
 #
 #  This is run from tmux. In order to have access to job control, a second script
 #  is simulated to be run in the active pane by using send-keys
-#  Since this doesn't really need the normal env, do things directly without
-#  any sourcing.
 #
 
-[ -z "$TMUX_BIN" ] && TMUX_BIN="tmux"
-
-#  Full path to tmux-menux plugin
+#  Full path to tmux-menus plugin
 D_TM_BASE_PATH="$(dirname -- "$(dirname -- "$(realpath "$0")")")"
 
-# Select next menu to display
-menu="$1"
-[ -z "$menu" ] && menu="$D_TM_BASE_PATH"/items/main.sh
-export TMUX_MENUS_EXTERNAL_MENU="$menu"
+. "$D_TM_BASE_PATH"/scripts/utils/define_tmux_bin.sh
 
 $TMUX_BIN send-keys C-z
 sleep 0.1 # give time for task to be suspended, and shell ready for input

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -22,7 +22,7 @@
         echo
         echo "$msg"
         echo
-    )
+    ) >/dev/stderr
     $TMUX_BIN display-message "$msg"
     exit 1
 }

--- a/scripts/helpers_minimal.sh
+++ b/scripts/helpers_minimal.sh
@@ -324,6 +324,9 @@ tmux_vers_check() {
         esac
     }
 
+    # Once a menu has been processed once, all version references should already be
+    # cached, so in the normal cached state this point will not be reached
+
     # If helpers aren't sourced yet, source them before continuing the version check
     $all_helpers_sourced || {
         # tmux_vers_check might be called as the other helpers are sourced, so
@@ -333,7 +336,7 @@ tmux_vers_check() {
         _v_comp="$_preserve_check_version"
     }
 
-    # Perform the actual version comparison check
+    # Perform the actual version comparison check, and then store it as a good/bad version
     tmux_vers_check_do_compare "$_v_comp"
 }
 
@@ -341,6 +344,8 @@ tpt_retrieve_running_tmux_vers() {
     #
     # If the variables defining the currently used tmux version needs to
     # be accessed before the first call to tmux_vers_ok this can be called.
+    # This will by nececity be called as config_setup() is processing, so unless
+    # caching is disabled, this won't be called by menus directly.
     #
     # log_it "tpt_retrieve_running_tmux_vers()"
     current_tmux_vers="$($TMUX_BIN -V | cut -d' ' -f2)"

--- a/scripts/helpers_minimal.sh
+++ b/scripts/helpers_minimal.sh
@@ -232,21 +232,25 @@ get_config() {
 #---------------------------------------------------------------
 
 select_safe_now_method() {
+    #
     # Select and save the time method for future use.
-    [ -n "$selected_get_time_mthd" ] && {
+    #
+    # Exports: selected_safe_now_mthd
+    #
+    [ -n "$selected_safe_now_mthd" ] && {
         error_msg_safe "Recursive call to: select_safe_now_method"
     }
 
     if [ -d /proc ] && [ -f /proc/version ]; then
-        selected_get_time_mthd="date" # Linux with sub-second precision
+        selected_safe_now_mthd="date" # Linux with sub-second precision
     elif [ "$(uname)" = "Linux" ]; then
-        selected_get_time_mthd="date" # Termux or other Linux variations
+        selected_safe_now_mthd="date" # Termux or other Linux variations
     elif command -v gdate >/dev/null; then
-        selected_get_time_mthd="gdate" # macOS, using GNU date if available
+        selected_safe_now_mthd="gdate" # macOS, using GNU date if available
     elif command -v perl >/dev/null; then
-        selected_get_time_mthd="perl" # Use Perl if date is not available
+        selected_safe_now_mthd="perl" # Use Perl if date is not available
     else
-        selected_get_time_mthd="date" # Fallback
+        selected_safe_now_mthd="date" # Fallback
     fi
 }
 
@@ -262,8 +266,8 @@ safe_now() {
     varname="$1"
     # validate_varname "$varname" "safe_now()()" # disabled for performance
 
-    # log_it "safe_now($varname) mthd: [$selected_get_time_mthd]"
-    case "$selected_get_time_mthd" in
+    # log_it "safe_now($varname) mthd: [$selected_safe_now_mthd]"
+    case "$selected_safe_now_mthd" in
     date) t_now="$(date +%s.%N)" ;;
     gdate) t_now="$(gdate +%s.%N)" ;;
     perl) t_now="$(perl -MTime::HiRes=time -E '$t = time; printf "%.9f\n", $t')" ;;
@@ -271,7 +275,7 @@ safe_now() {
         select_safe_now_method
 
         # to prevent infinite recursion, eunsure a valid timing method is now selected
-        case "$selected_get_time_mthd" in
+        case "$selected_safe_now_mthd" in
         date | gdate | perl) ;;
         *) error_msg_safe "safe_now($varname) - failed to select a timing method" ;;
         esac

--- a/scripts/helpers_minimal.sh
+++ b/scripts/helpers_minimal.sh
@@ -93,37 +93,6 @@ validate_varname() { # local usage tpt_digits_from_string() tpt_tmux_vers_suffix
     esac
 }
 
-define_profiling_env() {
-    # shellcheck disable=SC2154
-    case "$TMUX_MENUS_PROFILING" in
-    "1")
-        case "$profiling_sourced" in
-        "1") ;;
-        *)
-            # Here it is sourced  after D_TM_BASE_PATH is verified
-            # if the intent is to start timing the earliest stages of other scripts
-            # copy the below code using absolute paths
-            # shellcheck source=scripts/utils/dbg_profiling.sh
-            [ "$profiling_sourced" != 1 ] && . "$D_TM_BASE_PATH"/scripts/utils/dbg_profiling.sh
-            ;;
-        esac
-        ;;
-    *)
-        # profiling calls should not be left in the code base long term, this
-        # is primarily intended to capture them when profiling is temporarily disabled
-
-        # shellcheck disable=SC2317
-        profiling_update_time_stamps() {
-            :
-        }
-        # shellcheck disable=SC2317
-        profiling_display() {
-            :
-        }
-        ;;
-    esac
-}
-
 #---------------------------------------------------------------
 #
 #   get configuration

--- a/scripts/helpers_minimal.sh
+++ b/scripts/helpers_minimal.sh
@@ -71,7 +71,7 @@ source_all_helpers() {
 
 relative_path() {
     # remove D_TM_BASE_PATH prefix
-    # log_it "relative_path($1)"
+    # log_it "relative_path($1) - removing prefix: $D_TM_BASE_PATH"
     printf '%s\n' "${1#"$D_TM_BASE_PATH"/}"
 }
 
@@ -428,9 +428,7 @@ use_tmux_bin_socket() {
         # used to avoid picking up states from the outer tmux
         #
         f_name_socket="$(echo "$TMUX" | cut -d, -f 1)"
-        # log_it "><> f_name_socket [$f_name_socket]"
         socket="${f_name_socket##*/}"
-        # log_it "><> socket [$socket]"
         TMUX_BIN="$TMUX_BIN -L $socket"
         ;;
     esac

--- a/scripts/helpers_minimal.sh
+++ b/scripts/helpers_minimal.sh
@@ -52,7 +52,7 @@ log_it_minimal() {
 
 error_msg_safe() {
     #  Used when potentially called without having sourced everything
-    $all_helpers_sourced || source_all_helpers "error_msg_safe($*)"
+    $all_helpers_sourced || source_all_helpers "error_msg_safe()"
     error_msg "$1" "$2"
 }
 

--- a/scripts/helpers_minimal.sh
+++ b/scripts/helpers_minimal.sh
@@ -257,6 +257,8 @@ safe_now() {
     #  Assigning the supplied variable name instead of printing output in a subshell,
     #  for better performance
     #
+    # Exports: t_time_span
+    #
     varname="$1"
     # validate_varname "$varname" "safe_now()()" # disabled for performance
 
@@ -282,6 +284,18 @@ safe_now() {
         # if variable name provided set it to t_now
         eval "$varname=\"\$t_now\""
     }
+}
+
+time_span() {
+    #
+    # Calculates a time span compared to param 1
+    #
+    # Exports: t_time_span
+    #
+    _t_start="$1"
+
+    safe_now
+    t_time_span="$(echo "$t_now - $_t_start" | bc)"
 }
 
 #---------------------------------------------------------------

--- a/scripts/helpers_minimal.sh
+++ b/scripts/helpers_minimal.sh
@@ -218,6 +218,7 @@ select_safe_now_method() { # local usage by safe_now()
     [ -n "$selected_safe_now_mthd" ] && {
         error_msg_safe "Recursive call to: select_safe_now_method"
     }
+    # log_it "select_safe_now_method()"
 
     if [ -d /proc ] && [ -f /proc/version ]; then
         selected_safe_now_mthd="date" # Linux with sub-second precision
@@ -242,7 +243,12 @@ safe_now() {
     varname="$1"
     # validate_varname "$varname" "safe_now()()" # disabled for performance
 
-    # log_it "safe_now($varname) mthd: [$selected_safe_now_mthd]"
+    # [ -n "$selected_safe_now_mthd" ] && {
+    #     # first call will have no method defined, so this will recurse once it is
+    #     # set
+    #     log_it "safe_now($varname) mthd: [$selected_safe_now_mthd]"
+    # }
+
     case "$selected_safe_now_mthd" in
     date) t_now="$(date +%s.%N)" ;;
     gdate) t_now="$(gdate +%s.%N)" ;;

--- a/scripts/plugin_init.sh
+++ b/scripts/plugin_init.sh
@@ -68,6 +68,8 @@ if [[ -d "$d_cache" ]]; then
     safe_remove "$f_cache_known_tmux_vers"
     safe_remove "$f_cached_tmux_options"
     safe_remove "$f_cached_tmux_key_binds"
+    # Clear any errors from previous runs
+    safe_remove "$d_cache"/error-*
 
     #
     # If these are removed, it can't be detected if config changed, so

--- a/scripts/plugin_init.sh
+++ b/scripts/plugin_init.sh
@@ -10,11 +10,10 @@
 #
 
 bind_plugin_key() {
+    bind_cmd="$f_main_menu"
     if $cfg_use_whiptail; then
         bind_cmd="$d_scripts/external_dialog_trigger.sh"
         log_it "Will use alternate menu handler: $cfg_alt_menu_handler"
-    else
-        bind_cmd="$d_items/main.sh"
     fi
     cmd="bind-key"
     $cfg_use_notes && {
@@ -100,7 +99,9 @@ log_it
 #
 #  If custom inventory is used, update link to its main index
 #
-"$d_scripts"/update_custom_inventory.sh
+"$d_scripts"/update_custom_inventory.sh || {
+    error_msg "update_custom_inventory.sh reported error: $?"
+}
 
 #
 # Key is not bound until cache (if allowed) has been prepared, so normally

--- a/scripts/plugin_init.sh
+++ b/scripts/plugin_init.sh
@@ -99,8 +99,10 @@ log_it
 #
 #  If custom inventory is used, update link to its main index
 #
-"$d_scripts"/update_custom_inventory.sh || {
-    error_msg "update_custom_inventory.sh reported error: $?"
+$cfg_use_cache && {
+    "$d_scripts"/update_custom_inventory.sh || {
+        error_msg "update_custom_inventory.sh reported error: $?"
+    }
 }
 
 #

--- a/scripts/show_cmd.sh
+++ b/scripts/show_cmd.sh
@@ -92,7 +92,7 @@ sc_filter_bind_escapes_single() {
     # For those chars, display-menu will unescape them.
     sc_fbes_key=$1
     sc_fbes_output_var="$2"
-    sc_fbes_last_char=$(printf '%s' "$sc_fbes_key" | awk '{print substr($0,length,1)}')
+    sc_fbes_last_char=$(printf '%s\n' "$sc_fbes_key" | awk '{print substr($0,length,1)}')
 
     # log_it "sc_filter_bind_escapes_single($sc_fbes_key, $sc_fbes_output_var) [$sc_fbes_last_char]"
     [ -z "$sc_fbes_output_var" ] && {
@@ -106,7 +106,7 @@ sc_filter_bind_escapes_single() {
         ;;
     *)
         # shellcheck disable=SC1003 # in this case it is actually POSIX-compliant
-        clean_key=$(printf '%s' "$sc_fbes_key" | tr -d '\\')
+        clean_key=$(printf '%s\n' "$sc_fbes_key" | tr -d '\\')
         # printf '%s\n' "$clean_key"
         eval "$sc_fbes_output_var=\"$clean_key\""
         ;;
@@ -228,7 +228,7 @@ sc_clean_up_result() {
     #
     # prevent tmux variables from being expanded by dobeling # into ##
     #
-    sc_cur_s1=$(printf '%s' "$sc_cur_input" | sed 's/#/##/g')
+    sc_cur_s1=$(printf '%s\n' "$sc_cur_input" | sed 's/#/##/g')
 
     #
     # Replaces initial tmux-cmd with [TMUX] for clarity and to avoid risking

--- a/scripts/show_cmd.sh
+++ b/scripts/show_cmd.sh
@@ -71,11 +71,6 @@ sc_extract_key_bind() {
     if [ -z "$sc_ekb_keys" ]; then
         ekb_cmd_inverted=$(sc_invert_quotes "$sc_ekb_cmd")
         sc_ekb_keys=$(sc_extract_key_bind_run_awk "$sc_ekb_key_type" "$ekb_cmd_inverted")
-        # [ -n "$sc_ekb_keys" ] && {
-        #     _m="><> after inverting quotes: [$ekb_cmd_inverted]"
-        #     _m="$_m - found: $sc_ekb_keys"
-        #     log_it "$_m"
-        # }
     fi
 
     if [ -n "$sc_ekb_output_var" ]; then
@@ -142,7 +137,6 @@ sc_check_key_binds() {
         sc_filter_bind_escapes_single "$_key" sc_ckb_escaped
         sc_ckb_prefix_bind="${sc_ckb_prefix_bind}${sc_ckb_prefix_bind:+ }$sc_ckb_escaped"
     done
-    # log_it "><> sc_ckb_prefix_raw [$sc_ckb_prefix_raw] - sc_ckb_prefix_bind [$sc_ckb_prefix_bind]"
 
     sc_extract_key_bind root "$sc_ckb_cmd" sc_ckb_root_raw
     sc_ckb_root_bind=""

--- a/scripts/update_custom_inventory.sh
+++ b/scripts/update_custom_inventory.sh
@@ -20,10 +20,9 @@
 #  is present. If it is, then a menu pointer to this menu is included.
 #
 
-clear_cache_main() {
-    # log_it "UCI:clear_cache_main()"
-
-    safe_remove "$d_cache"/items/main
+clear_cache_main_index() {
+    # log_it "UCI:clear_cache_main_index()"
+    safe_remove "$d_cache_main_menu"
 }
 
 clear_cache_custom_items() {
@@ -45,7 +44,7 @@ clear_custom_content_template() {
 
 remove_custom_item_content() {
     # Remove custom item index page and all related caches
-    # log_it "UCI:remove_custom_item_content()"
+    # log_it "UCI:remove_custom_item_content() - $f_custom_items_index"
     safe_remove "$f_custom_items_index"
     clear_cache_custom_items # just to be sure its not pointing this file
 }
@@ -122,7 +121,7 @@ create_custom_index() {
         error_msg_safe "variable f_custom_items_content undefined"
     }
     safe_remove "$f_custom_items_content" # make sure its nothing there
-    clear_cache_main
+    clear_cache_main_index
 
     for custom_menu in $1; do
 
@@ -225,8 +224,8 @@ custom_items_prepare() {
     # log_it "UCI:custom_items_prepare()"
     if [ ! -d "$d_custom_items" ]; then
         [ -f "$f_chksum_custom" ] && {
-            log_it "UCI: Clearing main menu cache since custom items are gone"
-            safe_remove "$d_cache"/items/main # clear main menu cache
+            # log_it "UCI: Clearing main menu cache since custom items are gone"
+            clear_cache_main_index
         }
         # Folder missing, clear custom items cache and exit
         remove_custom_item_content

--- a/scripts/update_custom_inventory.sh
+++ b/scripts/update_custom_inventory.sh
@@ -257,4 +257,8 @@ f_custom_items_template="$D_TM_BASE_PATH"/templates/custom_index_template.sh
 # then inserted into the custom index and removed
 f_custom_items_content="$d_cache"/custom_items_content
 
-$cfg_use_cache && custom_items_prepare
+if $cfg_use_cache; then
+    custom_items_prepare
+else
+    error_msg "$0 - should not be run if caching is disabled!"
+fi

--- a/scripts/update_custom_inventory.sh
+++ b/scripts/update_custom_inventory.sh
@@ -260,5 +260,5 @@ f_custom_items_content="$d_cache"/custom_items_content
 if $cfg_use_cache; then
     custom_items_prepare
 else
-    error_msg "$0 - should not be run if caching is disabled!"
+    error_msg "$(relative_path "$0") - should not be run if caching is disabled!"
 fi

--- a/scripts/update_custom_inventory.sh
+++ b/scripts/update_custom_inventory.sh
@@ -70,14 +70,11 @@ custom_items_changed_check() {
     # log_it "UCI:custom_items_changed_check()"
 
     previous_content_chksum="$(checksum_content_read)"
-    # log_it "UCI:><> custom_items_changed_check() - previous  chksum: $previous_content_chksum"
-
     checksum_content_write
     current_content_chksum="$(checksum_content_read)"
     [ -z "$current_content_chksum" ] && {
         error_msg_safe "Failed to scan content in: $d_custom_items"
     }
-    # log_it "UCI:><> custom_items_changed_check() - current  chksum:  $current_content_chksum"
 
     [ "$previous_content_chksum" != "$current_content_chksum" ]
 }

--- a/scripts/utils/cache.sh
+++ b/scripts/utils/cache.sh
@@ -241,7 +241,7 @@ cfg_simple_style_border=\"$(cache_escape_special_chars "$cfg_simple_style_border
     fi
 
     # shellcheck disable=SC2154
-    printf '\n%s\n' "\
+    printf '\n%s' "\
 cfg_nav_next=\"$(cache_escape_special_chars "$cfg_nav_next")\"
 cfg_nav_prev=\"$(cache_escape_special_chars "$cfg_nav_prev")\"
 cfg_nav_home=\"$(cache_escape_special_chars "$cfg_nav_home")\"

--- a/scripts/utils/cache.sh
+++ b/scripts/utils/cache.sh
@@ -196,7 +196,6 @@ cache_write_plugin_params() {
     _f_params_tmp=$(mktemp) || {
         error_msg "cache_write_plugin_params() - Failed to create tmp config file"
     }
-    # fi
 
     #region param cache file
     # shellcheck disable=SC2154
@@ -283,17 +282,26 @@ t_minimal_display_time=\"$t_minimal_display_time\"
         if ! diff -q "$_f_params_tmp" "$f_cache_params" >/dev/null 2>&1; then
             # diff reports success if files don't differ, hence the !
             # If any params have changed, invalidate cache
+
+            # error_msg "><> verify existence of: $f_cached_tmux_options" 1 dont_display
+
             cache_clear "=======   Environment changed:  $(
                 diff "$_f_params_tmp" "$f_cache_params"
             )"
-            mv "$_f_params_tmp" "$f_cache_params" # replace even if unchanged
+            mv "$_f_params_tmp" "$f_cache_params"
+            [ -n "$cfg_log_file" ] && [ -f "$cfg_log_file" ] && {
+                # not strictly needed, the cache files will be created
+                # when needed, doing it here is mostly to ensure they are always
+                # available for debug checks
+                cache_save_options_defined_in_tmux
+            }
         else
             # log_it " config unchanged - param cache not cleared"
             rm "$_f_params_tmp"
         fi
     else
         log_it " param cache created"
-        mv "$_f_params_tmp" "$f_cache_params" # replace even if unchanged
+        mv "$_f_params_tmp" "$f_cache_params"
     fi
 }
 

--- a/scripts/utils/dbg_profiling.sh
+++ b/scripts/utils/dbg_profiling.sh
@@ -28,13 +28,6 @@
 #       profiling_display "get_config done"
 #
 
-# shellcheck disable=SC2154
-[ "$TMUX_MENUS_PROFILING" != "1" ] && {
-    echo
-    echo "ERROR: sourcing dbg_pofiling.sh without TMUX_MENUS_PROFILING being 1 [$0]"
-    exit 1
-}
-
 profiling_is_function_defined() {
     [ "$(command -v "$1")" = "$1" ]
 }
@@ -98,11 +91,11 @@ profiling_get_time() {
         date)
             _t="$(date +%s%N)"
             profiling_t_now="${_t%??????}" # Strip last 6 digits → milliseconds
-             ;;
+            ;;
         gdate)
             _t="$(gdate +%s%N)"
             profiling_t_now="${_t%??????}" # Strip last 6 digits → milliseconds
-             ;;
+            ;;
         perl)
             profiling_t_now="$(perl -MTime::HiRes=time -E 'say int(time * 1e3)')"
             ;;
@@ -146,16 +139,35 @@ profiling_display() {
 #
 #===============================================================
 
-[ "$profiling_sourced" = 1 ] && {
-    profiling_error_msg "scripts/utils/dbg_profiling.sh already sourced"
-}
+# shellcheck disable=SC2154
+case "$TMUX_MENUS_PROFILING" in
+1)
+    # profiling will be used
+    [ "$profiling_sourced" = 1 ] && {
+        profiling_error_msg "scripts/utils/dbg_profiling.sh already sourced"
+    }
+    profiling_select_timing_method
+    _m="Starting profiling for: $0 - using time method: $profiling_selected_get_time"
+    profiling_display_it "$_m"
+    profiling_get_time # start timer as early as possible
+    ;;
+*)
+    #
+    # This file should not be sourced normally and profiling calls should not be
+    # left in the code base long term, the below function overrides are primarily
+    # intended to disable them when profiling is temporarily disabled
+    #
+
+    # shellcheck disable=SC2317
+    profiling_update_time_stamps() {
+        :
+    }
+    # shellcheck disable=SC2317
+    profiling_display() {
+        :
+    }
+    ;;
+esac
 
 profiling_use_default_timer=0
 profiling_sourced=1 # Indicate this has been sourced
-
-_m="Starting profiling for: $0 - using time method: $profiling_selected_get_time"
-profiling_display_it "$_m"
-
-profiling_select_timing_method
-profiling_get_time # start timer as early as possible
-

--- a/scripts/utils/dbg_profiling.sh
+++ b/scripts/utils/dbg_profiling.sh
@@ -139,13 +139,14 @@ profiling_display() {
 #
 #===============================================================
 
+[ "$profiling_sourced" = 1 ] && {
+    profiling_error_msg "scripts/utils/dbg_profiling.sh already sourced"
+}
+
 # shellcheck disable=SC2154
 case "$TMUX_MENUS_PROFILING" in
 1)
     # profiling will be used
-    [ "$profiling_sourced" = 1 ] && {
-        profiling_error_msg "scripts/utils/dbg_profiling.sh already sourced"
-    }
     profiling_select_timing_method
     _m="Starting profiling for: $0 - using time method: $profiling_selected_get_time"
     profiling_display_it "$_m"

--- a/scripts/utils/define_tmux_bin.sh
+++ b/scripts/utils/define_tmux_bin.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Always sourced file - Fake bang path to help editors
+#
+#   Copyright (c) 2025: Jacob.Lundqvist@gmail.com
+#   License: MIT
+#
+#   Part of https://github.com/jaclu/tmux-menus
+#
+#  I use an env var TMUX_BIN to point at the current tmux, defined in my
+#  tmux.conf in order to pick the version matching the server running.
+#  If not found, it is set to whatever is in path, so should have no negative
+#  impact. In all calls to tmux I use $TMUX_BIN instead in the rest of this
+#  plugin.
+#
+[ -z "$TMUX_BIN" ] && TMUX_BIN="tmux"
+
+#
+# if multiple instances of the same tmux bin are used, errors can spill over
+# and cause issues in the other instance
+# this ensures that everything is run in the current environment
+#
+case "$TMUX_BIN" in
+*-L*) ;; # already using socket
+*)
+    #
+    # in case an inner tmux is using this plugin, make sure the current socket is
+    # used to avoid picking up states from the outer tmux
+    #
+    # shellcheck disable=SC2154
+    f_name_socket="$(echo "$TMUX" | cut -d, -f 1)"
+    socket="${f_name_socket##*/}"
+    TMUX_BIN="$TMUX_BIN -L $socket"
+    ;;
+esac

--- a/scripts/utils/helpers_full.sh
+++ b/scripts/utils/helpers_full.sh
@@ -159,8 +159,6 @@ get_digits_from_string() {
     echo "$_i"
 }
 
-
-
 normalize_bool_param() {
     #
     #  Normalizes a string into a boolean value usable in conditionals.
@@ -267,7 +265,7 @@ check_speed_cutoff() {
     if [ "$(echo "$t_time_span < $cut_off" | bc)" -eq 1 ]; then
         t_minimal_display_time=0.1
     else
-        log_it "  Failed cutoff time, considered a slow system: $t_time_span >= $cut_off"
+        # log_it "  Failed cutoff time, considered a slow system: $t_time_span >= $cut_off"
         # for slower systems
         t_minimal_display_time=0.5
     fi

--- a/scripts/utils/helpers_full.sh
+++ b/scripts/utils/helpers_full.sh
@@ -159,32 +159,23 @@ get_digits_from_string() {
     echo "$_i"
 }
 
+
+
 normalize_bool_param() {
     #
-    # Take a boolean style text param and convert it into an actual boolean
-    # that can be used in your code. If the param starts with @ it is first read
-    # from tmux
+    #  Normalizes a string into a boolean value usable in conditionals.
     #
-    # For performance reasons all @menus... params are cached once when cache is
-    # initialized. In case some other tmux variable needs to be checked,
-    # ignore this cache and do a read by providing a third param, "no_cache" or similar,
-    # it's content doesn't matter, if a 3rd param is provided, the cache will be ignored.
+    #  If the param starts with @, it's treated as a tmux option and read
+    #  from cache (intended for @menus* vars) unless a third argument is provided,
+    #  in which case the cache is bypassed.
     #
-    #    Examples of usage:
+    #  Supports both direct values (e.g. "yes", "no", "true", "false") and
+    #  tmux option lookups with a fallback default.
     #
-    # if normalize_bool_param "@menus_without_prefix" "$default_no_prefix"; then
-    #     cfg_no_prefix=true
-    # else
-    #     cfg_no_prefix=false
-    # fi
-    #
-    #  if normalize_bool_param "$wt_pasting" false no_cache; then
-    #
-    #  # boolean check on regular variable - no default is needed
-    #  a="YES"
-    #  if normalize_bool_param "$a"; then
-    #      do thing is it was true
-    #  fi
+    #  Examples:
+    #    if normalize_bool_param "@menus_enabled" true; then ...
+    #    if normalize_bool_param "$some_flag"; then ...
+    #    if normalize_bool_param "@var" false no_cache; then ...
     #
     nbp_param="$1"
     nbp_default="$2"  # only needed for tmux options
@@ -301,12 +292,20 @@ config_setup() {
         safe_remove "$f_no_cache_hint" config_setup
         create_param_cache
     else
+        cfg_use_cache=false
         touch "$f_no_cache_hint"
         tmux_get_plugin_options
     fi
 }
 
 safe_remove() {
+    #
+    # Ensures what is to be removed is not a "dangerous" path that would
+    # cause a mess of the file system
+    # If param 2 is empty, an extra check will be made that the pattern is prefixed
+    # by the location of this plugin, only use param 2 if something outside
+    # the plugin location needs to be removed
+    #
     pattern="$1"
     skip_plugin_name_in_path_check="$2"
 

--- a/scripts/utils/helpers_full.sh
+++ b/scripts/utils/helpers_full.sh
@@ -35,6 +35,10 @@ error_msg() {
     exit_code="${2:-0}"
     log_it_minimal "error_msg($em_msg, $exit_code)"
 
+    # Disable logging for the remainder of error_msg processing, to avoid getting
+    # log-flooded, unless exit is not requested
+    [ "$exit_code" -gt -1 ] && cfg_log_file=""
+
     [ -z "$TMUX" ] && {
         # with no tmux env, dumping it to stderr & log-file is the only output options
         log_it_minimal "***  This does not seem to be running in a tmux env  ***"
@@ -281,7 +285,7 @@ check_speed_cutoff() {
 config_setup() {
     # Examins tmux env, and depending on caching config either plainly read
     # tmux.conf, or prepare a f_cache_params
-    # log_it "config_setup()"
+    log_it "config_setup()"
 
     # only need default_use_cache at this point but might as well get them all
     tmux_get_defaults

--- a/scripts/utils/helpers_full.sh
+++ b/scripts/utils/helpers_full.sh
@@ -260,13 +260,13 @@ check_speed_cutoff() {
     cut_off="$1"
 
     # log_it "-T- check_speed_cutoff($cut_off)"
-    safe_now
     # shellcheck disable=SC2154
-    t_init="$(echo "$t_now - $t_script_start" | bc)"
-    if [ "$(echo "$t_init < $cut_off" | bc)" -eq 1 ]; then
+    time_span "$t_script_start"
+    # shellcheck disable=SC2154
+    if [ "$(echo "$t_time_span < $cut_off" | bc)" -eq 1 ]; then
         t_minimal_display_time=0.1
     else
-        log_it "  Failed cutoff time, considered a slow system: $t_init >= $cut_off"
+        log_it "  Failed cutoff time, considered a slow system: $t_time_span >= $cut_off"
         # for slower systems
         t_minimal_display_time=0.5
     fi

--- a/scripts/utils/std_alone_log.sh
+++ b/scripts/utils/std_alone_log.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+sal_error() {
+    echo "ERROR: std_alone_log.sh: $1" >/dev/stderr
+    exit 1
+}
+
+log_msg="$1"
+
+#  Full path to tmux-menus plugin
+D_TM_BASE_PATH="$(dirname -- "$(dirname -- "$(dirname -- "$(realpath "$0")")")")"
+
+f_plugin_params_cache="$D_TM_BASE_PATH"/cache/plugin_params
+
+[ -f "$f_plugin_params_cache" ] && {
+    # shellcheck source=/dev/null
+    . "$f_plugin_params_cache" || sal_error "Failed to source: $f_plugin_params_cache"
+    [ -n "$cfg_log_file" ] && {
+        echo "sal: $log_msg" >>"$cfg_log_file"
+        exit 0
+    }
+}
+
+echo "sal [no log file]: $log_msg" >/dev/stderr

--- a/scripts/utils/tmux.sh
+++ b/scripts/utils/tmux.sh
@@ -374,8 +374,12 @@ tmux_get_plugin_options() { # new init
 
     tmux_get_option _tmux_conf "@menus_config_file" "$default_tmux_conf"
     # Handle the case of ~ or $HOME being wrapped in single quotes in tmux.conf
-    # shellcheck disable=SC2154
-    fix_home_path "$_tmux_conf" cfg_tmux_conf
+    if [ -n "$_tmux_conf" ]; then
+        fix_home_path "$_tmux_conf" cfg_tmux_conf
+    else
+        # shellcheck disable=SC2034
+        cfg_tmux_conf=""
+    fi
 
     # shellcheck disable=SC2154
     [ "$log_file_forced" != 1 ] && {
@@ -383,7 +387,12 @@ tmux_get_plugin_options() { # new init
         # log_it "tmux will read cfg_log_file"
         tmux_get_option _log_file "@menus_log_file" "$default_log_file"
         # Handle the case of ~ or $HOME being wrapped in single quotes in tmux.conf
-        fix_home_path "$_log_file" cfg_log_file
+        if [ -n "$_log_file" ]; then
+            fix_home_path "$_log_file" cfg_log_file
+        else
+            # shellcheck disable=SC2034
+            cfg_log_file=""
+        fi
     }
     #
     #  Generic plugin setting I use to add Notes to keys that are bound

--- a/scripts/utils/tmux.sh
+++ b/scripts/utils/tmux.sh
@@ -237,7 +237,6 @@ fix_home_path() {
     echo "$fhp_path" | grep -q \$HOME && {
         error_msg "fix_home_path() - Failed to expand \$HOME in: $fhp_path"
     }
-    # log_it "><> fix_home_path() result:[$fhp_path]"
     eval "$fhp_varname=\"\$fhp_path\""
 }
 
@@ -369,10 +368,8 @@ tmux_get_plugin_options() { # new init
     #
     if tmux_vers_check 3.1 &&
         normalize_bool_param "@use_bind_key_notes_in_plugins" No; then
-        # log_it "><> using notes"
         cfg_use_notes=true
     else
-        # log_it "><> ignoring notes"
         # shellcheck disable=SC2034
         cfg_use_notes=false
     fi

--- a/scripts/utils/tmux.sh
+++ b/scripts/utils/tmux.sh
@@ -148,7 +148,7 @@ tmux_get_option() {
         _line=""
     elif ! tmux_vers_check 1.8; then
         # before 1.8 no support for user options
-        log_it "tmux_get_option() - tmux < 1.8 - using default"
+        log_it "tmux_get_option() - tmux < 1.8 - User options not available, using default"
         _line=""
     elif $tgo_use_cache; then
         cache_save_options_defined_in_tmux
@@ -202,7 +202,7 @@ fix_home_path() {
     fhp_path="$1"
     fhp_varname="$2"
 
-    log_it "fix_home_path($fhp_varname,$fhp_path)"
+    # log_it "fix_home_path($fhp_varname,$fhp_path)"
 
     if false; then
         # For performance reasons full variable name assessment when is disabled by default

--- a/scripts/utils/tmux.sh
+++ b/scripts/utils/tmux.sh
@@ -461,7 +461,7 @@ tmux_error_handler_assign() { # cache references
     fi
     # ensure it exists
     [ ! -d "$d_errors" ] && mkdir -p "$d_errors"
-    f_tmux_err="$d_errors"/tmux-err
+    f_tmux_err="$d_errors"/tmux-errror-in-last-command-if-not-empty
 
     #
     # Run the actual command and save any error output. If the command succeeded

--- a/scripts/utils/tmux.sh
+++ b/scripts/utils/tmux.sh
@@ -417,7 +417,7 @@ tmux_error_handler_assign() { # cache references
     cmd_simplified="$*"
 
     $teh_debug && {
-        # in principle this should be done every time, but limitted to when
+        # in principle this should be done every time, but limited to when
         # logging, to minimize overhead
         validate_varname "$varname" "tmux_error_handler_assign()"
 


### PR DESCRIPTION
### Added

- time_span(org_time) - sets t_time_span to time since org_time
- copied definition of TMUX*BIN to scripts/utils/define_tmux_bin.sh in order to ensure
  sockets will always be used to minimize risk for collisions if an inner tmux uses
  this plugin in stdalone tools, like `external_dialog*\*`
- scripts/utils/std*alone_log.sh - Tries to pick up current log_file if defined
  otherwise logs to /dev/stderr, used by external tools that don't load the entire
  environment like `external_dialog*\*`

### Changed

- Bug fix: fix_home_path() - Now correctly handles the odd behaviour of tmux 3.4
- Bug fix: forgetting to check if cache is active in dialog_handling.sh:handle_dynamic()
- Bug fix: verify_menu_runable() - escape ' in order to display errors in menu code
- Bug fix: scripts/update_custom_inventory.sh - ensure main menu is cleared if
  custom items are removed, to ensure main menu stops offering custom menus

- menu_parse() - optimized processing
- menu_generate_part() - abort early for empty parts
- tmux_error_handler_assign() - streamlined for performance and added inline comments
- get_menu_items_sorted() & cache_read_menu_items() - simplified code, slight performance boost
- Added run_if_found() - makes code cleaner
- Improved error detection when parsing and displaying menus
- 'Move pane' & 'Move Window' - Corrected check when pane is marked in another context
- static_files_reduction() - simplified
- sort_menu_items() -> get_menu_items_sorted()
- moved all profiling init to dbg_profiling.sh
