### PR TITLE
Improve version extraction

### DIFF
--- a/scripts/helpers_minimal.sh
+++ b/scripts/helpers_minimal.sh
@@ -434,8 +434,11 @@ tpt_digits_from_string() { # local usage by tpt_retrieve_running_tmux_vers()
     [ -z "$varname" ] && error_msg_safe "tpt_digits_from_string() - no variable name!"
     [ -z "$2" ] && error_msg_safe "tpt_digits_from_string() - no param!"
 
-    # Remove "-rc" suffix and extract digits using parameter expansion
-    _i=$(echo "$2" | cut -d'-' -f1 | tr -cd '0-9') # Keep only digits
+    # Remove "next-" prefix, "-rc" suffix and extract digits using parameter expansion
+    _i=$2
+    _i=${_i##next-}                 # Remove leading "next-" if present
+    _i=${_i%%-rc*}                  # Remove trailing "-rc" and anything after
+    _i=$(echo "$_i" | tr -cd '0-9') # Keep only digits
 
     # Check if result is empty after digit extraction
     [ -z "$_i" ] && error_msg_safe "tpt_digits_from_string() - result empty"


### PR DESCRIPTION
 When tmux is compiled from git is gets a 'next-' prefix added to the  version number. Use sh pattern removal to remove 'next-' prefix and  '-rc*' suffix.